### PR TITLE
Add ViewModel generator script

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ A TypeScript-powered web application starter with modern tools and frameworks. T
 - `src/index.ts` configures routes and bootstraps the application.
 
 ### Adding New Views
-1. Create a new view model extending `BaseViewModel` inside `src/components`.
-2. Provide a template via `setTemplate()` or override `template`.
+1. Run `npx ts-node scripts/create-viewmodel.ts <Name> [--test]` to generate a view model stub (and optional test).
+2. Provide a template via `setTemplate()` or override `template` if you need more than the default header.
 3. Register a route in `src/index.ts` that renders your view model.
 
 This starter provides just enough structure to grow a Knockout application without locking you in. Use the patterns in `AppViewModel` as a guide for creating additional pages.

--- a/scripts/create-viewmodel.ts
+++ b/scripts/create-viewmodel.ts
@@ -1,0 +1,62 @@
+#!/usr/bin/env ts-node
+import { existsSync, mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+const args = process.argv.slice(2);
+if (args.length === 0) {
+  console.error('Usage: create-viewmodel <Name> [--test]');
+  process.exit(1);
+}
+
+const name = args[0];
+const withTest = args.includes('--test');
+const className = `${name}ViewModel`;
+const componentDir = join('src', 'components');
+const filePath = join(componentDir, `${className}.ts`);
+
+if (!existsSync(componentDir)) {
+  mkdirSync(componentDir, { recursive: true });
+}
+if (existsSync(filePath)) {
+  console.error(`${filePath} already exists`);
+  process.exit(1);
+}
+
+const content = `import { BaseViewModel } from '../core/BaseViewModel';
+
+export class ${className} extends BaseViewModel {
+  constructor(context: PageJS.Context | undefined) {
+    super(context);
+    this.setTemplate(\`<h1>${name}</h1>\`);
+  }
+}
+`;
+
+writeFileSync(filePath, content, { flag: 'wx' });
+console.log(`Created ${filePath}`);
+
+if (withTest) {
+  const testDir = 'tests';
+  const testPath = join(testDir, `${className}.test.ts`);
+  if (!existsSync(testDir)) {
+    mkdirSync(testDir, { recursive: true });
+  }
+  if (existsSync(testPath)) {
+    console.error(`${testPath} already exists`);
+    process.exit(1);
+  }
+
+  const testContent = `import { describe, it, expect } from 'vitest';
+import { ${className} } from '../src/components/${className}';
+
+describe('${className}', () => {
+  it('renders default template', () => {
+    const vm = new ${className}(undefined);
+    const html = vm.renderHtml();
+    expect(html).toContain('${name}');
+  });
+});
+`;
+  writeFileSync(testPath, testContent, { flag: 'wx' });
+  console.log(`Created ${testPath}`);
+}


### PR DESCRIPTION
## Summary
- create `create-viewmodel.ts` for generating new view model stubs
- document script usage in README

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686471ef01e083269a2c6061f8d30aff